### PR TITLE
add passes component to link svf-llvm

### DIFF
--- a/svf-llvm/CMakeLists.txt
+++ b/svf-llvm/CMakeLists.txt
@@ -57,6 +57,7 @@ else()
     target
     transformutils
     demangle
+    passes
   )
 endif()
 


### PR DESCRIPTION
I'm trying to build for LLVM 19 but I get dynamic linking errors for 

```
            // New Pass Manager (LLVM 20+)
            llvm::PassBuilder PB;
            llvm::FunctionPassManager FPM;
            FPM.addPass(llvm::UnifyFunctionExitNodesPass());
            llvm::LoopAnalysisManager LAM;
            llvm::FunctionAnalysisManager FAM;
            llvm::CGSCCAnalysisManager CGAM;
            llvm::ModuleAnalysisManager MAM;
            PB.registerModuleAnalyses(MAM);
            PB.registerCGSCCAnalyses(CGAM);
            PB.registerFunctionAnalyses(FAM);
            PB.registerLoopAnalyses(LAM);
            PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
            FPM.run(const_cast<llvm::Function&>(fun), FAM);
#endif
```

to include the PassBuilder we can force linking of the passes component